### PR TITLE
fix sha256 for abseil-cpp

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,9 +19,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Abseil
 http_archive(
     name = "com_google_absl",
-    sha256 = "5cb4f68fa1768077a52f0d5b620dcc517df4feebecbe37a0b2d739ded3151844",
+    sha256 = "b7b5fbd2e0b727ef156e73f184aac7edbeeea413ebd81c45b2aae6f9bda125a0",
     strip_prefix = "abseil-cpp-master",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
+    urls = ["https://github.com/abseil/abseil-cpp/archive/8a394b19c149cab50534b04c5e21d42bc2217a7d.zip"],
 )
 
 # gflags

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Abseil
 http_archive(
     name = "com_google_absl",
-    sha256 = "aba4062bd32067c77bb47a8ba9f6e310777a315b0563cdea0f38156bc7b915a9",
+    sha256 = "5cb4f68fa1768077a52f0d5b620dcc517df4feebecbe37a0b2d739ded3151844",
     strip_prefix = "abseil-cpp-master",
     urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
 )


### PR DESCRIPTION
ERROR: Analysis of target '//vxsig:vxsig' failed; build aborted: no such package '@com_google_absl//absl/strings': java.io.IOException: Error downloading [https://github.com/abseil/abseil-cpp/archive/master.zip] to /home/user1/.cache/bazel/_bazel_root/a7d7e842e51dab441ec3b70d9bb69313/external/com_google_absl/master.zip: Checksum was 5cb4f68fa1768077a52f0d5b620dcc517df4feebecbe37a0b2d739ded3151844 but wanted aba4062bd32067c77bb47a8ba9f6e310777a315b0563cdea0f38156bc7b915a9